### PR TITLE
Requires.NotDefault

### DIFF
--- a/src/main/CodeContracts/Requires.cs
+++ b/src/main/CodeContracts/Requires.cs
@@ -313,5 +313,34 @@ namespace CodeContracts
         {
             throw new ArgumentException(message, parameterName);
         }
+
+				/// <summary>
+				/// Throws an <see cref="ArgumentException"/>
+				/// </summary>
+				/// <param name="value">The object to be tested.</param>
+				/// <param name="parameterName">Name of the parameter.</param>
+				/// <param name="unformattedMessage">The message of the exception to be thrown should the requirement fail.</param>
+				/// <param name="args">Arguments to be passed to the formatting method when formatting the exception message.</param>
+				[Pure, DebuggerStepThrough]
+				public static void NotDefault<T>(T value, string parameterName)
+				{
+					NotDefault(value, parameterName, "The parameter '{0}' was passed in with a default value, was expected to be nondefault.", parameterName);
+				}
+
+			/// <summary>
+			/// Throws an <see cref="ArgumentException"/>
+			/// </summary>
+			/// <param name="value">The object to be tested.</param>
+			/// <param name="parameterName">Name of the parameter.</param>
+			/// <param name="unformattedMessage">The message of the exception to be thrown should the requirement fail.</param>
+			/// <param name="args">Arguments to be passed to the formatting method when formatting the exception message.</param>
+			[Pure, DebuggerStepThrough]
+	    public static void NotDefault<T>(T value, string parameterName, string unformattedMessage, params object[] args)
+	    {
+				if (value == null || value.Equals(default(T)))
+				{
+					throw new ArgumentException(String.Format(unformattedMessage, args));
+				}
+	    }
     }
 }

--- a/src/specs/CodeContracts-Specs/RequiresSpecs.cs
+++ b/src/specs/CodeContracts-Specs/RequiresSpecs.cs
@@ -176,6 +176,48 @@ namespace CodeContracts.Specs
                 Requires.True(true, "par");
             }
         }
+
+	    [TestFixture]
+	    public class when_requires_that_not_default_providing_default_value_type
+	    {
+		    [Test]
+				[ExpectedException(typeof(ArgumentException))]
+		    public void should_throw()
+		    {
+			    Requires.NotDefault(default(int), "value", "the parameter '{0}' is default when it should not be", "value");
+		    }
+	    }
+
+	    [TestFixture]
+	    public class when_requires_that_not_default_providing_default_reference_type
+	    {
+		    [Test]
+		    [ExpectedException(typeof(ArgumentException))]
+		    public void should_throw()
+		    {
+			    Requires.NotDefault(default(string), "value");
+		    }
+	    }
+
+			[TestFixture]
+	    public class when_requires_that_not_default_providing_nondefault_value_type
+	    {
+		    [Test]
+		    public void should_not_throw()
+		    {
+			    Requires.NotDefault(1, "value");
+		    }
+	    }
+
+	    [TestFixture]
+	    public class when_requires_that_not_default_providing_nondefault_reference_type
+	    {
+		    [Test]
+		    public void should_not_throw()
+		    {
+			    Requires.NotDefault("test", "value");
+		    }
+	    }
     }
 }
 


### PR DESCRIPTION
Hey,
I've added Requires.NotDefault, to be able to require both value types and reference types to not have their default value (null for reference types and default(T) for value types).
Also, there's passing unit tests for this new method.
